### PR TITLE
Update documented script to fix NUnit XML and generated report location

### DIFF
--- a/Zap/README.md
+++ b/Zap/README.md
@@ -72,13 +72,12 @@ Additionally, you can take advantage of handlebars templating for a simple repor
    sudo npm install -g handlebars-cmd
 
    cat <<EOF > owaspzap/nunit-template.hbs
-   {{#each site}}
 
    <test-run
        id="2"
        name="Owasp test"
-       start-time="{{../[@generated]}}"  >
-       <test-suite
+       start-time="{{@generated}}">
+       {{#each site}}<test-suite
            id="{{@index}}"
            type="Assembly"
            name="{{[@name]}}"
@@ -86,15 +85,15 @@ Additionally, you can take advantage of handlebars templating for a simple repor
            failed="{{alerts.length}}">
            <attachments>
                <attachment>
-                   <filePath>owaspzap/report.html</filePath>
+                   <filePath>$BUILD_SOURCESDIRECTORY/owaspzap/report.html</filePath>
                </attachment>
            </attachments>
-       {{#each alerts}}<test-case
-           id="{{@index}}"
-           name="{{alert}}"
-           result="Failed"
-           fullname="{{alert}}"
-           time="1">
+           {{#each alerts}}<test-case
+               id="{{@index}}"
+               name="{{alert}}"
+               result="Failed"
+               fullname="{{alert}}"
+               time="1">
                <failure>
                    <message>
                        <![CDATA[{{{desc}}}]]>
@@ -114,11 +113,11 @@ Additionally, you can take advantage of handlebars templating for a simple repor
                        {{/each}}]]>
                    </stack-trace>
                </failure>
-       </test-case>
-       {{/each}}
+           </test-case>
+           {{/each}}
        </test-suite>
+       {{/each}}
    </test-run>
-   {{/each}}
    EOF
   displayName: 'owasp nunit template'
   condition: always()


### PR DESCRIPTION
As identified in issue #4, when multiple sites are returned, the script provided in the documentation can create multiple `<test-run>` nodes. Per [the NUnit 3.0 documentation](https://github.com/nunit/docs/wiki/Test-Result-XML-Format), `<test-run>` is the root element of the document, so only one instance is allowed. The provided script creates this element once for each site, violating this rule. The proposed documentation change resolves this by converting each site into a test suite within the run (instead of representing each site as a single test run containing a single test suite). This fix ensures a single root node in the generated XML.

In addition, Azure DevOps requires an absolute path to retrieve the related `report.html` file. The script is using a relative path, leading to a warning that it is "Skipping attachment as it is not available on disk". The update to the documentation resolves that issue as well by specifying the absolute path using an environment variable.